### PR TITLE
Filter out unsupported messages

### DIFF
--- a/_message_graphs.py
+++ b/_message_graphs.py
@@ -57,6 +57,8 @@ def _parse_chat(chat, date_filter, wordlist):
 	oldest_date = datetime.strptime(date_filter, '%Y-%m-%d')
 
 	for message in chat['messages']:
+		if message['type'] == 'unsupported':
+			continue
 		person = 'B'
 		if('from' in message):
 			if metrics['A']['name'] in message['from']:


### PR DESCRIPTION
Some messages are unsupported by some versions of Telegram, which caused the following error when running the script. 
![image](https://user-images.githubusercontent.com/24320926/157828911-c458e50d-d90c-4176-9f54-7e3e82dd68f2.png)
```
Traceback (most recent call last):
  File "/tmp/TelegramChatStats/./telegram-statistics.py", line 196, in <module>
    main()
  File "/tmp/TelegramChatStats/./telegram-statistics.py", line 177, in main
    raw = calculate_graphs(chat_data, date_filter, wordlist)
  File "/tmp/TelegramChatStats/./telegram-statistics.py", line 118, in calculate_graphs
    return _message_graphs(chat_data, date_filter, wordlist)
  File "/tmp/TelegramChatStats/_message_graphs.py", line 171, in _message_graphs
    metrics = _parse_chat(chat, date_filter, wordlist)
  File "/tmp/TelegramChatStats/_message_graphs.py", line 69, in _parse_chat
    date_obj = datetime.strptime(message['date'], '%Y-%m-%dT%H:%M:%S')
KeyError: 'date'
```

The structure of a unsupported message is similar to this:
```
{'id': 43178, 'type': 'unsupported'}
```
Therefore I add an if statement at the top of the for loop to check if the type of this message is 'unsupported'; if yes, skip this message.